### PR TITLE
Old style Tool registration is moved to generic setup based tool registration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .*.cfg
 .installed.cfg
 .mr.developer.cfg
+pip-selfcheck.json
 .hg/
 .bzr/
 .svn/
@@ -27,6 +28,7 @@ fake-eggs/
 parts/
 dist/
 var/
+local/
 Products/LoginLockout/i18n/rebuild_i18n.log
 .coverage
 htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ htmlcov/
 .DS_Store
 include/
 lib/
+
+# IDE
+/.idea
+/*.sublime-*

--- a/Products/LoginLockout/profiles/default/toolset.xml
+++ b/Products/LoginLockout/profiles/default/toolset.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<tool-setup>
+    <required tool_id="loginlockout_tool"
+           class="Products.LoginLockout.loginlockout_tool.LoginLockoutTool"/>
+</tool-setup>

--- a/Products/LoginLockout/setuphandlers.py
+++ b/Products/LoginLockout/setuphandlers.py
@@ -40,9 +40,6 @@ def install(portal):
     for (pas, interface) in move_to_top_for.iteritems():
         movePluginToTop(pas, PLUGIN_ID, interface, out)
 
-    # add tool
-    addTool(portal, PROJECTNAME, TOOL_ID)
-
     # install configlet
 
     print >> out, "Successfully installed %s." % PROJECTNAME
@@ -100,14 +97,6 @@ def movePluginToTop(pas, plugin_id, interface_name, out):
     while registry.listPlugins(interface)[0][0] != plugin_id:
         registry.movePluginsUp(interface, [plugin_id])
     print >> out, "Moved " + plugin_id + " to top in " + interface_name + "."
-
-
-def addTool(portal, product_name, tool_id):
-    try:
-        ctool = getToolByName(portal, tool_id)  # NOQA
-    except AttributeError:
-        portal.manage_addProduct[product_name].manage_addTool(
-            product_name, None)
 
 
 def installConfiglets(portal, out, configlets, uninstall=False):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     ],
     extras_require={
         'test': [
+            'plone.app.testing',
             'Products.PloneTestCase',
             'zope.testing'
         ],


### PR DESCRIPTION
When I run the test got bellows errors:
```
File "*******/.cache/buildout/eggs/Products.GenericSetup-1.8.8-py2.7.egg/Products/GenericSetup/tool.py", line 1245, in _doRunImportStep
    return handler(context)
   - __traceback_info__: Products.LoginLockout.various
  File "*******/www/python/CONTRIBUTIONS_FOLDER/Products.LoginLockout/Products/LoginLockout/setuphandlers.py", line 141, in setupVarious
    install(site)
  File "*********/www/python/CONTRIBUTIONS_FOLDER/Products.LoginLockout/Products/LoginLockout/setuphandlers.py", line 44, in install
    addTool(portal, PROJECTNAME, TOOL_ID)
  File "*********www/python/CONTRIBUTIONS_FOLDER/Products.LoginLockout/Products/LoginLockout/setuphandlers.py", line 109, in addTool
    portal.manage_addProduct[product_name].manage_addTool(
AttributeError: manage_addTool
```
Solution I did:
make a file `toolset.xml` inside profile directory and let genericsetup to handle the tool registration.