### PR TITLE
Fix the attr error when call getUserId

### DIFF
--- a/Products/LoginLockout/plugin.py
+++ b/Products/LoginLockout/plugin.py
@@ -460,10 +460,11 @@ def logged_in_handler(event):
 
     user = event.object
     portal = getSite()
-    if getattr(user, 'getUserId', None) is None:
-        userid = str(user)
-    else:
+    try:
         userid = user.getUserId()
+    except AttributeError:
+        # root (zmi) user doesn't have 'getUserId' attribute
+        userid = str(user)
 
     #TODO: don't hardcode name?
     if hasattr(portal.acl_users, 'login_lockout_plugin'):


### PR DESCRIPTION
Somehow passing 'getattr' method still raise 'AttributeError' when call 'getUserId'. I can't reproduce locally.

```
Traceback (innermost last):

Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
Module Products.CMFFormController.ControllerBase, line 232, in getNext
Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.CMFFormController.FSControllerPythonScript, line 105, in __call__
Module Products.CMFFormController.Script, line 145, in __call__
Module Products.CMFCore.FSPythonScript, line 127, in __call__
Module Shared.DC.Scripts.Bindings, line 322, in __call__
Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
Module Products.PythonScripts.PythonScript, line 344, in _exec
Module script, line 38, in logged_in
<FSControllerPythonScript at /06/mnt/lecc/logged_in>
Line 38
Module Products.PlonePAS.tools.membership, line 641, in loginUser
Module zope.event, line 31, in notify
Module zope.component.event, line 24, in dispatch
Module zope.component._api, line 136, in subscribers
Module zope.component.registry, line 321, in subscribers
Module zope.interface.adapter, line 585, in subscribers
Module Products.LoginLockout.plugin, line 455, in logged_in_handler
AttributeError: getUserId
```
