### PR TITLE
Control panel module with configuration settings form is created  

### DIFF
--- a/Products/LoginLockout/configure.zcml
+++ b/Products/LoginLockout/configure.zcml
@@ -6,8 +6,9 @@
     i18n_domain="LoginLockout">
 
   <include file="skins.zcml" />
-  <include file="profiles.zcml" />
   <include file="controlpanel.zcml" />
+  <include file="profiles.zcml" />
+  <include file="upgrades.zcml" />
 
 <subscriber
         for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"

--- a/Products/LoginLockout/configure.zcml
+++ b/Products/LoginLockout/configure.zcml
@@ -7,6 +7,7 @@
 
   <include file="skins.zcml" />
   <include file="profiles.zcml" />
+  <include file="controlpanel.zcml" />
 
 <subscriber
         for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"

--- a/Products/LoginLockout/controlpanel.py
+++ b/Products/LoginLockout/controlpanel.py
@@ -1,11 +1,11 @@
 # _*_ coding: utf-8 _*_
 from .interfaces import ILoginLockoutSettings
 from plone.app.registry.browser import controlpanel
-from plone import api
 from plone.app.iterate import PloneMessageFactory as _
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.utils import safe_hasattr
+from zope.site.hooks import getSite
 from zope.component import adapter
 from zope.interface import implementer
 from z3c.form import button
@@ -19,7 +19,7 @@ class LoginLockoutSettingsAdapter(object):
     def __init__(self, context):
         """ """
         self.context = context
-        self.portal = api.portal.get()
+        self.portal = getSite()
         self.encoding = 'utf-8'
         registry = queryUtility(IRegistry)
         self.settings = registry.forInterface(

--- a/Products/LoginLockout/controlpanel.py
+++ b/Products/LoginLockout/controlpanel.py
@@ -1,0 +1,100 @@
+# _*_ coding: utf-8 _*_
+from .interfaces import ILoginLockoutSettings
+from plone.app.registry.browser import controlpanel
+from plone import api
+from plone.app.iterate import PloneMessageFactory as _
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.CMFPlone.utils import safe_hasattr
+from zope.component import adapter
+from zope.interface import implementer
+from z3c.form import button
+from zope.component import queryUtility
+
+
+@adapter(IPloneSiteRoot)
+@implementer(ILoginLockoutSettings)
+class LoginLockoutSettingsAdapter(object):
+    """ """
+    def __init__(self, context):
+        """ """
+        self.context = context
+        self.portal = api.portal.get()
+        self.encoding = 'utf-8'
+        registry = queryUtility(IRegistry)
+        self.settings = registry.forInterface(
+            ILoginLockoutSettings,
+            prefix='Products.LoginLockout')
+
+    @property
+    def max_attempts(self):
+        """ """
+        return self.settings.max_attempts
+
+    @max_attempts.setter
+    def max_attempts(self, value):
+        """ """
+        if safe_hasattr(self.settings, 'max_attempts'):
+            self.settings.max_attempts = value
+
+    @property
+    def reset_period(self):
+        """ """
+        return self.settings.reset_period
+
+    @reset_period.setter
+    def reset_period(self, value):
+        """ """
+        if safe_hasattr(self.settings, 'reset_period'):
+            self.settings.reset_period = value
+
+    @property
+    def whitelist_ips(self):
+        """ """
+        return self.settings.whitelist_ips
+
+    @whitelist_ips.setter
+    def whitelist_ips(self, value):
+        """ """
+        if safe_hasattr(self.settings, 'whitelist_ips'):
+            self.settings.whitelist_ips = value
+
+    @property
+    def fake_client_ip(self):
+        """ """
+        return self.settings.fake_client_ip
+
+    @fake_client_ip.setter
+    def fake_client_ip(self, value):
+        """ """
+        if safe_hasattr(self.settings, 'fake_client_ip'):
+            self.settings.fake_client_ip = value
+
+
+class LoginLockoutSettingsForm(controlpanel.RegistryEditForm):
+
+    id = 'LoginLockoutSettings'
+    label = _(u'LoginLockout Settings')
+    schema = ILoginLockoutSettings
+    schema_prefix = 'Products.LoginLockout'
+
+    @button.buttonAndHandler(_('Save'), name=None)
+    def handleSave(self, action):
+        self.save()
+
+    @button.buttonAndHandler(_('Cancel'), name='cancel')
+    def handleCancel(self, action):
+        super(LoginLockoutSettingsForm, self).handleCancel(self, action)
+
+    def save(self):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return False
+
+        self.applyChanges(data)
+        return True
+
+
+class LoginLockoutSetting(controlpanel.ControlPanelFormWrapper):
+    form = LoginLockoutSettingsForm

--- a/Products/LoginLockout/controlpanel.py
+++ b/Products/LoginLockout/controlpanel.py
@@ -2,99 +2,16 @@
 from .interfaces import ILoginLockoutSettings
 from plone.app.registry.browser import controlpanel
 from plone.app.iterate import PloneMessageFactory as _
-from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from Products.CMFPlone.utils import safe_hasattr
-from zope.site.hooks import getSite
-from zope.component import adapter
-from zope.interface import implementer
-from z3c.form import button
-from zope.component import queryUtility
-
-
-@adapter(IPloneSiteRoot)
-@implementer(ILoginLockoutSettings)
-class LoginLockoutSettingsAdapter(object):
-    """ """
-    def __init__(self, context):
-        """ """
-        self.context = context
-        self.portal = getSite()
-        self.encoding = 'utf-8'
-        registry = queryUtility(IRegistry)
-        self.settings = registry.forInterface(
-            ILoginLockoutSettings,
-            prefix='Products.LoginLockout')
-
-    @property
-    def max_attempts(self):
-        """ """
-        return self.settings.max_attempts
-
-    @max_attempts.setter
-    def max_attempts(self, value):
-        """ """
-        if safe_hasattr(self.settings, 'max_attempts'):
-            self.settings.max_attempts = value
-
-    @property
-    def reset_period(self):
-        """ """
-        return self.settings.reset_period
-
-    @reset_period.setter
-    def reset_period(self, value):
-        """ """
-        if safe_hasattr(self.settings, 'reset_period'):
-            self.settings.reset_period = value
-
-    @property
-    def whitelist_ips(self):
-        """ """
-        return self.settings.whitelist_ips
-
-    @whitelist_ips.setter
-    def whitelist_ips(self, value):
-        """ """
-        if safe_hasattr(self.settings, 'whitelist_ips'):
-            self.settings.whitelist_ips = value
-
-    @property
-    def fake_client_ip(self):
-        """ """
-        return self.settings.fake_client_ip
-
-    @fake_client_ip.setter
-    def fake_client_ip(self, value):
-        """ """
-        if safe_hasattr(self.settings, 'fake_client_ip'):
-            self.settings.fake_client_ip = value
+from z3c.form import form
+from plone.z3cform import layout
 
 
 class LoginLockoutSettingsForm(controlpanel.RegistryEditForm):
 
-    id = 'LoginLockoutSettings'
-    label = _(u'LoginLockout Settings')
     schema = ILoginLockoutSettings
     schema_prefix = 'Products.LoginLockout'
-
-    @button.buttonAndHandler(_('Save'), name=None)
-    def handleSave(self, action):
-        self.save()
-
-    @button.buttonAndHandler(_('Cancel'), name='cancel')
-    def handleCancel(self, action):
-        super(LoginLockoutSettingsForm, self).handleCancel(self, action)
-
-    def save(self):
-        data, errors = self.extractData()
-        if errors:
-            self.status = self.formErrorsMessage
-            return False
-
-        self.applyChanges(data)
-        return True
+    form.extends(controlpanel.RegistryEditForm)
 
 
-class LoginLockoutSetting(controlpanel.ControlPanelFormWrapper):
-    form = LoginLockoutSettingsForm
+LoginLockoutSetting = layout.wrap_form(LoginLockoutSettingsForm, controlpanel.ControlPanelFormWrapper)
+LoginLockoutSetting.label = _(u'LoginLockout Settings')

--- a/Products/LoginLockout/controlpanel.zcml
+++ b/Products/LoginLockout/controlpanel.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="LoginLockout">
+
+    <browser:page
+        name="loginlockout-settings"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        class=".controlpanel.LoginLockoutSetting"
+        permission="zope2.View"
+    />
+    <adapter factory=".controlpanel.LoginLockoutSettingsAdapter" />
+</configure>

--- a/Products/LoginLockout/controlpanel.zcml
+++ b/Products/LoginLockout/controlpanel.zcml
@@ -7,7 +7,6 @@
         name="loginlockout-settings"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
         class=".controlpanel.LoginLockoutSetting"
-        permission="zope2.View"
+        permission="cmf.ManagePortal"
     />
-    <adapter factory=".controlpanel.LoginLockoutSettingsAdapter" />
 </configure>

--- a/Products/LoginLockout/interfaces.py
+++ b/Products/LoginLockout/interfaces.py
@@ -23,7 +23,7 @@ class ILoginLockoutSettings(Interface):
         title=_(u'Lock logins to IP Ranges'),
         description=u'List of IP Ranges which Client IP must be in to login. Empty disables',
         default=u'',
-        required=True
+        required=False
     )
 
     fake_client_ip = schema.Bool(

--- a/Products/LoginLockout/profiles/default/controlpanel.xml
+++ b/Products/LoginLockout/profiles/default/controlpanel.xml
@@ -10,4 +10,28 @@
   <permission>Manage portal</permission>
  </configlet>
 
+ <configlet title="LoginLockout History" action_id="LoginLockoutHistory"
+    appId="LoginLockout" category="Products" condition_expr=""
+    icon_expr="string:${portal_url}/lock_icon.gif"
+    url_expr="string:${portal_url}/loginlockout_history"
+    visible="True" i18n:attributes="title">
+  <permission>Manage portal</permission>
+ </configlet>
+
+ <configlet title="LoginLockout History (password changes)" action_id="LoginLockoutPasswordHistory"
+    appId="LoginLockout" category="Products" condition_expr=""
+    icon_expr="string:${portal_url}/lock_icon.gif"
+    url_expr="string:${portal_url}/loginlockout_last_password_changes"
+    visible="True" i18n:attributes="title">
+  <permission>Manage portal</permission>
+ </configlet>
+
+ <configlet title="LoginLockout Settings" action_id="LoginLockoutSettings"
+    appId="LoginLockout" category="Products" condition_expr=""
+    icon_expr="string:${portal_url}/lock_icon.gif"
+    url_expr="string:${portal_url}/@@loginlockout-settings"
+    visible="True" i18n:attributes="title">
+  <permission>Manage portal</permission>
+ </configlet>
+
 </object>

--- a/Products/LoginLockout/profiles/default/metadata.xml
+++ b/Products/LoginLockout/profiles/default/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <version>20180218-01</version>
+  <dependencies></dependencies>
+</metadata>

--- a/Products/LoginLockout/profiles/default/registry.xml
+++ b/Products/LoginLockout/profiles/default/registry.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <registry>
-  <records interface="Products.LoginLockout.interfaces.ILoginLockoutSettings" prefix="Products.LoginLockout"/>
+  <records interface="Products.LoginLockout.interfaces.ILoginLockoutSettings" prefix='Products.LoginLockout'/>
 </registry>

--- a/Products/LoginLockout/skins/loginlockout_templates/loginlockout_settings.cpt
+++ b/Products/LoginLockout/skins/loginlockout_templates/loginlockout_settings.cpt
@@ -154,6 +154,11 @@
         <a href="loginlockout_history" i18n:translate="">Login history</a>
         &bull;
         <a href="loginlockout_last_password_changes" i18n:translate="">History password changes</a>
+        &bull;
+        <a
+          tal:attributes="href
+              string:${context/portal_url}/@@loginlockout-settings"
+          i18n:translate="">Configuration Settings</a>
       </form>
     </span>
   </body>

--- a/Products/LoginLockout/tests.py
+++ b/Products/LoginLockout/tests.py
@@ -60,6 +60,11 @@ def setUp(doctest):
                 raise
         commit()
 
+    def get_loginlockout_settings():
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ILoginLockoutSettings, prefix="Products.LoginLockout")
+        return settings
+
     doctest.globs.update(locals())
 #
 #     def afterSetUp(self):

--- a/Products/LoginLockout/upgrades.py
+++ b/Products/LoginLockout/upgrades.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
+from plone.registry.interfaces import IRegistry
+from Products.LoginLockout.interfaces import ILoginLockoutSettings
+from zope.component import getUtility
+
+import logging
+
+log = logging.getLogger('LoginLockout')
+
+
+def migrate_portal_properties(portal):
+    """ """
+    p_tool = getToolByName(portal, 'portal_properties', None)
+    loginlockout_properties = getattr(p_tool, 'loginlockout_properties', None)
+
+    if loginlockout_properties is None:
+        # nothing to migrate
+        return
+
+    loginlockout_registry = getUtility(IRegistry).forInterface(
+        ILoginLockoutSettings,
+        prefix='Products.LoginLockout')
+
+    if loginlockout_registry is None:
+        # nothing to migrate
+        return
+
+    setattr(loginlockout_registry, 'fake_client_ip', bool(loginlockout_properties.getProperty('fake_client_ip')))
+    setattr(loginlockout_registry, 'reset_period', float(loginlockout_properties.getProperty('reset_period')))
+    setattr(loginlockout_registry, 'max_attempts', int(loginlockout_properties.getProperty('max_attempts')))
+
+
+def run_upgrade_2009031001_to_2018021801(context):
+    """ """
+    plone_root = aq_parent(aq_parent(context))
+    log.info('Upgrade steps from version 20090310-01 to 20180218-01 is starting')
+
+    log.info('values to be migrated `fake_client_ip, reset_period, reset_period`')
+
+    migrate_portal_properties(plone_root)
+
+    log.info('Upgrade has been done successfully')

--- a/Products/LoginLockout/upgrades.zcml
+++ b/Products/LoginLockout/upgrades.zcml
@@ -1,0 +1,14 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeSteps
+     profile="Products.LoginLockout:default"
+     source="20090310-01"
+     destination="20180218-01">
+      <genericsetup:upgradeStep
+        handler=".upgrades.run_upgrade_2009031001_to_2018021801"
+        title="Run Products.LoginLockout: 20090310-01 to 20180218-01"
+        description="Migration from portal properties to portal registry"
+        />
+  </genericsetup:upgradeSteps>
+</configure>

--- a/README.rst
+++ b/README.rst
@@ -40,28 +40,12 @@ Features
 Configuration
 -------------
 
-Go to the Plone Control Panel -> LoginLockout Configuration Panel -> Configuration Settings,
-there you can changes these defaults:
+Go to the Plone Control Panel -> LoginLockout Settings , there you can changes these defaults:
 
 - allowed incorrect attempts: 3
 - reset period: 24 hours
 - whitelist_ips: [] # any origin IP is allowed
 - Fake Client IP: false
-
-Go to Plone Control Panel::
-    >>> from zope.component import getUtility
-    >>> from plone.registry.interfaces import IRegistry
-    >>> from Products.LoginLockout.interfaces import ILoginLockoutSettings
-    >>> settings = getUtility(IRegistry).forInterface(ILoginLockoutSettings, prefix="Products.LoginLockout")
-    >>> settings.fake_client_ip
-    False
-    >>> admin_browser.open(portal.absolute_url() + '/plone_control_panel')
-    >>> admin_browser.getLink('LoginLockout Configuration Panel').click()
-    >>> admin_browser.getLink('Configuration Settings').click()
-    >>> admin_browser.getControl(name='form.widgets.fake_client_ip:list').value = ['1']
-    >>> admin_browser.getControl(name='form.buttons.save').click()
-    >>> settings.fake_client_ip
-    True
 
 
 Details
@@ -277,6 +261,19 @@ Password Reset History
 ----------------------
 
     >>> # TODO tests go here
+
+Loginlockout Settings
+---------------------
+
+    >>> settings = get_loginlockout_settings()
+    >>> settings.fake_client_ip
+    False
+    >>> admin_browser.open(portal.absolute_url() + '/plone_control_panel')
+    >>> admin_browser.getLink('LoginLockout Settings').click()
+    >>> admin_browser.getControl(name='form.widgets.fake_client_ip:list').value = ['1']
+    >>> admin_browser.getControl(name='form.buttons.save').click()
+    >>> settings.fake_client_ip
+    True
 
 
 Manual Installation

--- a/README.rst
+++ b/README.rst
@@ -40,12 +40,28 @@ Features
 Configuration
 -------------
 
-Go to the ZMI -> portal_properties -> loginlockout_properties,
+Go to the Plone Control Panel -> LoginLockout Configuration Panel -> Configuration Settings,
 there you can changes these defaults:
 
 - allowed incorrect attempts: 3
 - reset period: 24 hours
 - whitelist_ips: [] # any origin IP is allowed
+- Fake Client IP: false
+
+Go to Plone Control Panel::
+    >>> from zope.component import getUtility
+    >>> from plone.registry.interfaces import IRegistry
+    >>> from Products.LoginLockout.interfaces import ILoginLockoutSettings
+    >>> settings = getUtility(IRegistry).forInterface(ILoginLockoutSettings, prefix="Products.LoginLockout")
+    >>> settings.fake_client_ip
+    False
+    >>> admin_browser.open(portal.absolute_url() + '/plone_control_panel')
+    >>> admin_browser.getLink('LoginLockout Configuration Panel').click()
+    >>> admin_browser.getLink('Configuration Settings').click()
+    >>> admin_browser.getControl(name='form.widgets.fake_client_ip:list').value = ['1']
+    >>> admin_browser.getControl(name='form.buttons.save').click()
+    >>> settings.fake_client_ip
+    True
 
 
 Details
@@ -183,7 +199,7 @@ and now they can log in again::
 IP Lockdown
 -----------
 
-You can optionally ensure logins are only possible for certain IP address ranges. 
+You can optionally ensure logins are only possible for certain IP address ranges.
 
 By default IP Locking is disabled.
 


### PR DESCRIPTION
Although Loginlockout settings can be update from plone registry editor but for simplicity I have created a form.
This is indirectly related to #14 (steps to move portal_properties to registry)

One thing need to solve: 
```
<browser:page
       name="loginlockout-settings"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       class=".controlpanel.LoginLockoutSetting"
       permission="zope2.View"  />
```
Permission should not be public, (I tried with cmf.ManagePortal got component lookup error)